### PR TITLE
Add flags to match mir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ set(CMAKE_AUTOMOC ON)
 # Use C++11 and warnings
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c11 -Wall")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto -ffat-lto-objects -fPIC -fno-strict-aliasing")
 
 find_package(PkgConfig)
 pkg_check_modules(ANDROIDPROPS libandroid-properties)


### PR DESCRIPTION
This seems to fix our issues we got with mir v1.0.0 on both on arm64 (localetime segfault)
and armhf (nullptr in binary blobs).