### PR TITLE
SessionSwitcher: hides all sessions on inactive display

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,13 @@
+String stashFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.udeb,*.dsc,*.changes,*.buildinfo,lintian.txt'
+String archiveFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.udeb,*.dsc,*.changes,*.buildinfo'
+
 pipeline {
   agent any
   stages {
     stage('Build source') {
       steps {
         sh '/usr/bin/build-source.sh'
-        stash(name: 'source', includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt')
+        stash(name: 'source', includes: stashFileList)
         cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
       }
     }
@@ -17,7 +20,7 @@ pipeline {
               unstash 'source'
               sh '''export architecture="armhf"
 build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-armhf')
+              stash(includes: stashFileList, name: 'build-armhf')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
 
@@ -29,7 +32,7 @@ build-binary.sh'''
               unstash 'source'
               sh '''export architecture="arm64"
     build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-arm64')
+              stash(includes: stashFileList, name: 'build-arm64')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
           },
@@ -39,7 +42,7 @@ build-binary.sh'''
               unstash 'source'
               sh '''export architecture="amd64"
     build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-amd64')
+              stash(includes: stashFileList, name: 'build-amd64')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
           }
@@ -52,7 +55,7 @@ build-binary.sh'''
         unstash 'build-armhf'
         unstash 'build-arm64'
         unstash 'build-amd64'
-        archiveArtifacts(artifacts: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo', fingerprint: true, onlyIfSuccessful: true)
+        archiveArtifacts(artifacts: archiveFileList, fingerprint: true, onlyIfSuccessful: true)
         sh '''/usr/bin/build-repo.sh'''
       }
     }

--- a/src/mir_screen.cpp
+++ b/src/mir_screen.cpp
@@ -142,6 +142,20 @@ usc::MirScreen::MirScreen(
         log_exception_in(__func__);
         throw;
     }
+
+    try
+    {
+        // We can be constructed after the initial_configuration() event.
+        // Count active outputs based on current configuration so that we have
+        // the correct info from the begining.
+        active_outputs = count_active_outputs(*display->configuration());
+    }
+    catch(...)
+    {
+        // Probably the configuration is not ready. Ignore. Hopefully
+        // initial_configuration() will be called later.
+        log_exception_in(__func__);
+    }
 }
 
 usc::MirScreen::~MirScreen() = default;

--- a/src/mir_screen.cpp
+++ b/src/mir_screen.cpp
@@ -246,6 +246,9 @@ try
 
     if (has_active_outputs(*displayConfig))
         compositor->start();
+
+    // Setting power mode is considered a configuration change.
+    configuration_applied(displayConfig);
 }
 catch (std::exception const&)
 {

--- a/src/mir_screen.cpp
+++ b/src/mir_screen.cpp
@@ -1,5 +1,7 @@
 /*
  * Copyright © 2014-2015 Canonical Ltd.
+ * Copyright (C) 2020 UBports foundation.
+ * Author(s): Ratchanan Srirattanamet <ratchanan@ubports.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -124,8 +126,7 @@ usc::MirScreen::MirScreen(
     std::shared_ptr<mir::compositor::Compositor> const& compositor,
     std::shared_ptr<mir::graphics::Display> const& display)
     : compositor{compositor},
-      display{display},
-      active_outputs_handler{[](ActiveOutputs const&){}}
+      display{display}
 {
     try
     {
@@ -158,15 +159,23 @@ void usc::MirScreen::turn_off(OutputFilter output_filter)
 }
 
 void usc::MirScreen::register_active_outputs_handler(
-    ActiveOutputsHandler const& handler)
+    void * ownerKey, ActiveOutputsHandler const& handler)
 {
     // It's not ideal to call the handler under lock, but we need this to
     // guarantee that after this function returns no invocation of the old
     // handler will be in progress. Alternatively, we would need to implement
     // an event loop.
     std::lock_guard<std::mutex> lock{active_outputs_mutex};
-    active_outputs_handler = handler;
-    active_outputs_handler(active_outputs);
+    active_outputs_handlers[ownerKey] = handler;
+    // Call only the new handler immediately.
+    handler(active_outputs);
+}
+
+void usc::MirScreen::unregister_active_outputs_handler(
+    void * ownerKey)
+{
+    std::lock_guard<std::mutex> lock{active_outputs_mutex};
+    active_outputs_handlers.erase(ownerKey);
 }
 
 void usc::MirScreen::initial_configuration(
@@ -174,7 +183,8 @@ void usc::MirScreen::initial_configuration(
 {
     std::lock_guard<std::mutex> lock{active_outputs_mutex};
     active_outputs = count_active_outputs(*display_configuration);
-    active_outputs_handler(active_outputs);
+    for (auto const& pair: active_outputs_handlers)
+        pair.second(active_outputs);
 }
 
 void usc::MirScreen::configuration_applied(
@@ -182,7 +192,8 @@ void usc::MirScreen::configuration_applied(
 {
     std::lock_guard<std::mutex> lock{active_outputs_mutex};
     active_outputs = count_active_outputs(*display_configuration);
-    active_outputs_handler(active_outputs);
+    for (auto const& pair: active_outputs_handlers)
+        pair.second(active_outputs);
 }
 
 void usc::MirScreen::base_configuration_updated(

--- a/src/mir_screen.h
+++ b/src/mir_screen.h
@@ -1,5 +1,7 @@
 /*
  * Copyright © 2014-2015 Canonical Ltd.
+ * Copyright (C) 2020 UBports foundation.
+ * Author(s): Ratchanan Srirattanamet <ratchanan@ubports.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -23,6 +25,7 @@
 #include <chrono>
 #include <memory>
 #include <mutex>
+#include <map>
 
 namespace mir
 {
@@ -43,7 +46,8 @@ public:
     // From Screen
     void turn_on(OutputFilter output_filter) override;
     void turn_off(OutputFilter output_filter) override;
-    void register_active_outputs_handler(ActiveOutputsHandler const& handler) override;
+    void register_active_outputs_handler(void * ownerKey, ActiveOutputsHandler const& handler) override;
+    void unregister_active_outputs_handler(void * ownerKey) override;
 
     // From DisplayConfigurationObserver
     void initial_configuration(
@@ -73,7 +77,7 @@ private:
     std::shared_ptr<mir::graphics::Display> const display;
 
     std::mutex active_outputs_mutex;
-    ActiveOutputsHandler active_outputs_handler;
+    std::map<void *, ActiveOutputsHandler> active_outputs_handlers;
     ActiveOutputs active_outputs;
 };
 

--- a/src/screen.h
+++ b/src/screen.h
@@ -1,5 +1,7 @@
 /*
  * Copyright © 2014-2015 Canonical Ltd.
+ * Copyright (C) 2020 UBports foundation.
+ * Author(s): Ratchanan Srirattanamet <ratchanan@ubports.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -50,7 +52,9 @@ public:
     virtual void turn_on(OutputFilter filter) = 0;
     virtual void turn_off(OutputFilter filter) = 0;
     virtual void register_active_outputs_handler(
-        ActiveOutputsHandler const& handler) = 0;
+        void * ownerKey, ActiveOutputsHandler const& handler) = 0;
+    virtual void unregister_active_outputs_handler(
+        void * ownerKey) = 0;
 
 protected:
     Screen() = default;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1,5 +1,7 @@
 /*
  * Copyright © 2014-2015 Canonical Ltd.
+ * Copyright (C) 2020 UBports foundation.
+ * Author(s): Ratchanan Srirattanamet <ratchanan@ubports.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -298,6 +300,9 @@ std::shared_ptr<usc::Screen> usc::Server::the_screen()
                 the_display());
 
             the_display_configuration_observer_registrar()->register_interest(mir_screen);
+            // the_session_switcher() can't call the_screen() as that will create a
+            // dependency loop. Set it here instead.
+            the_session_switcher()->set_screen(mir_screen);
 
             return mir_screen;
         });

--- a/src/session_switcher.cpp
+++ b/src/session_switcher.cpp
@@ -1,5 +1,7 @@
 /*
  * Copyright © 2014 Canonical Ltd.
+ * Copyright (C) 2020 UBports foundation.
+ * Author(s): Ratchanan Srirattanamet <ratchanan@ubports.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -18,13 +20,37 @@
 
 #include "session_switcher.h"
 #include "spinner.h"
+#include "screen.h"
 
 #include <mir/frontend/session.h>
 
 usc::SessionSwitcher::SessionSwitcher(std::shared_ptr<Spinner> const& spinner)
     : spinner_process{spinner},
-      booting{true}
+      booting{true},
+      has_active_outputs{true}
 {
+}
+
+usc::SessionSwitcher::~SessionSwitcher()
+{
+    if (auto screen = screen_weak.lock())
+        screen->unregister_active_outputs_handler(this);
+}
+
+void usc::SessionSwitcher::set_screen(std::shared_ptr<Screen> const& screen)
+{
+    if (auto old_screen = screen_weak.lock()) // Just in case
+        old_screen->unregister_active_outputs_handler(this);
+
+    screen_weak = screen;
+
+    screen->register_active_outputs_handler(this,
+        [this](ActiveOutputs const& active_outputs) {
+            has_active_outputs =
+                (active_outputs.internal + active_outputs.external != 0);
+            update_displayed_sessions();
+        }
+    );
 }
 
 void usc::SessionSwitcher::add(std::shared_ptr<Session> const& session, pid_t pid)
@@ -94,6 +120,9 @@ void usc::SessionSwitcher::mark_ready(mir::frontend::Session const* session)
 
 void usc::SessionSwitcher::update_displayed_sessions()
 {
+    if (!has_active_outputs)
+        return hide_all_sessions();
+
     hide_uninteresting_sessions();
 
     bool show_spinner = false;
@@ -150,6 +179,14 @@ void usc::SessionSwitcher::hide_uninteresting_sessions()
         {
             pair.second.session->hide();
         }
+    }
+}
+
+void usc::SessionSwitcher::hide_all_sessions()
+{
+    for (auto const& pair : sessions)
+    {
+        pair.second.session->hide();
     }
 }
 

--- a/src/session_switcher.h
+++ b/src/session_switcher.h
@@ -1,5 +1,7 @@
 /*
  * Copyright © 2014 Canonical Ltd.
+ * Copyright (C) 2020 UBports foundation.
+ * Author(s): Ratchanan Srirattanamet <ratchanan@ubports.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -28,11 +30,14 @@
 namespace usc
 {
 class Spinner;
+class Screen;
 
 class SessionSwitcher : public DMMessageHandler, public SessionMonitor
 {
 public:
     explicit SessionSwitcher(std::shared_ptr<Spinner> const& spinner);
+
+    ~SessionSwitcher();
 
     /* From SessionMonitor */
     void add(std::shared_ptr<Session> const& session, pid_t pid) override;
@@ -43,11 +48,14 @@ public:
     void set_active_session(std::string const& name) override;
     void set_next_session(std::string const& name) override;
 
+    void set_screen(std::shared_ptr<Screen> const& screen);
+
 private:
     enum class ShowMode { as_active, as_next };
 
     void update_displayed_sessions();
     void hide_uninteresting_sessions();
+    void hide_all_sessions();
     bool is_session_ready_for_display(std::string const& name);
     bool is_session_expected_to_become_ready(std::string const& name);
     void show_session(std::string const& name, ShowMode show_mode);
@@ -73,6 +81,8 @@ private:
     std::string next_name;
     std::string spinner_name;
     bool booting;
+    std::weak_ptr<Screen> screen_weak;
+    bool has_active_outputs;
 };
 
 }

--- a/src/unity_display_service.cpp
+++ b/src/unity_display_service.cpp
@@ -1,5 +1,7 @@
 /*
  * Copyright © 2015 Canonical Ltd.
+ * Copyright (C) 2020 UBports foundation.
+ * Author(s): Ratchanan Srirattanamet <ratchanan@ubports.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -88,7 +90,7 @@ usc::UnityDisplayService::UnityDisplayService(
     connection->request_name(dbus_display_service_name);
     connection->add_filter(handle_dbus_message_thunk, this);
 
-    screen->register_active_outputs_handler(
+    screen->register_active_outputs_handler(this,
         [this] (ActiveOutputs const& active_outputs_arg)
         {
             this->loop->enqueue(
@@ -102,7 +104,7 @@ usc::UnityDisplayService::UnityDisplayService(
 
 usc::UnityDisplayService::~UnityDisplayService()
 {
-    screen->register_active_outputs_handler([](ActiveOutputs const&){});
+    screen->unregister_active_outputs_handler(this);
 }
 
 ::DBusHandlerResult usc::UnityDisplayService::handle_dbus_message_thunk(

--- a/tests/include/usc/test/mock_screen.h
+++ b/tests/include/usc/test/mock_screen.h
@@ -1,5 +1,7 @@
 /*
  * Copyright © 2015 Canonical Ltd.
+ * Copyright (C) 2020 UBports foundation.
+ * Author(s): Ratchanan Srirattanamet <ratchanan@ubports.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -33,7 +35,8 @@ struct MockScreen : usc::Screen
 {
     MOCK_METHOD1(turn_on, void(OutputFilter));
     MOCK_METHOD1(turn_off, void(OutputFilter));
-    MOCK_METHOD1(register_active_outputs_handler, void(ActiveOutputsHandler const&));
+    MOCK_METHOD2(register_active_outputs_handler, void(void *, ActiveOutputsHandler const&));
+    MOCK_METHOD1(unregister_active_outputs_handler, void(void*));
 };
 
 }

--- a/tests/integration-tests/test_unity_display_service.cpp
+++ b/tests/integration-tests/test_unity_display_service.cpp
@@ -1,5 +1,7 @@
 /*
  * Copyright © 2015 Canonical Ltd.
+ * Copyright (C) 2020 UBports foundation.
+ * Author(s): Ratchanan Srirattanamet <ratchanan@ubports.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -42,10 +44,16 @@ namespace
 
 struct FakeScreen : ut::MockScreen
 {
-    void register_active_outputs_handler(usc::ActiveOutputsHandler const& handler)
+    void register_active_outputs_handler(void * /*ownerKey*/, usc::ActiveOutputsHandler const& handler)
     {
         std::lock_guard<std::mutex> lock{active_outputs_mutex};
         active_outputs_handler = handler;
+    }
+
+    void unregister_active_outputs_handler(void * /*ownerKey*/)
+    {
+        std::lock_guard<std::mutex> lock{active_outputs_mutex};
+        active_outputs_handler = [](usc::ActiveOutputs const&){};
     }
 
     void notify_active_outputs(usc::ActiveOutputs const& active_outputs)

--- a/tests/unit-tests/test_mir_screen.cpp
+++ b/tests/unit-tests/test_mir_screen.cpp
@@ -176,6 +176,24 @@ TEST_F(AMirScreen, configuration_applied_calls_handler)
     EXPECT_THAT(active_outputs, Eq(config_active_outputs));
 }
 
+TEST_F(AMirScreen, turning_on_calls_handler)
+{
+    mir_screen->register_active_outputs_handler(this, active_outputs_handler);
+
+    turn_all_displays_on();
+
+    EXPECT_THAT(active_outputs, Eq(usc::ActiveOutputs{1, 0}));
+}
+
+TEST_F(AMirScreen, turning_off_calls_handler)
+{
+    mir_screen->register_active_outputs_handler(this, active_outputs_handler);
+
+    turn_all_displays_off();
+
+    EXPECT_THAT(active_outputs, Eq(usc::ActiveOutputs{0, 0}));
+}
+
 TEST_F(AMirScreen, support_multiple_handlers)
 {
     bool another_handler_called = false;

--- a/tests/unit-tests/test_mir_screen.cpp
+++ b/tests/unit-tests/test_mir_screen.cpp
@@ -155,7 +155,7 @@ TEST_F(AMirScreen, registered_handler_is_called_immediately)
 {
     mir_screen->register_active_outputs_handler(this, active_outputs_handler);
 
-    EXPECT_THAT(active_outputs, Eq(usc::ActiveOutputs{}));
+    EXPECT_THAT(active_outputs, Eq(usc::ActiveOutputs{1, 0}));
 }
 
 TEST_F(AMirScreen, initial_configuration_calls_handler)

--- a/tests/unit-tests/test_mir_screen.cpp
+++ b/tests/unit-tests/test_mir_screen.cpp
@@ -1,5 +1,7 @@
 /*
  * Copyright © 2015 Canonical Ltd.
+ * Copyright (C) 2020 UBports foundation.
+ * Author(s): Ratchanan Srirattanamet <ratchanan@ubports.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -151,14 +153,14 @@ TEST_F(AMirScreen, restarts_compositing_after_turn_off_internal_if_active_output
 
 TEST_F(AMirScreen, registered_handler_is_called_immediately)
 {
-    mir_screen->register_active_outputs_handler(active_outputs_handler);
+    mir_screen->register_active_outputs_handler(this, active_outputs_handler);
 
     EXPECT_THAT(active_outputs, Eq(usc::ActiveOutputs{}));
 }
 
 TEST_F(AMirScreen, initial_configuration_calls_handler)
 {
-    mir_screen->register_active_outputs_handler(active_outputs_handler);
+    mir_screen->register_active_outputs_handler(this, active_outputs_handler);
 
     mir_screen->initial_configuration(ut::fake_shared(stub_display_configuration));
 
@@ -167,9 +169,28 @@ TEST_F(AMirScreen, initial_configuration_calls_handler)
 
 TEST_F(AMirScreen, configuration_applied_calls_handler)
 {
-    mir_screen->register_active_outputs_handler(active_outputs_handler);
+    mir_screen->register_active_outputs_handler(this, active_outputs_handler);
 
     mir_screen->configuration_applied(ut::fake_shared(stub_display_configuration));
 
     EXPECT_THAT(active_outputs, Eq(config_active_outputs));
+}
+
+TEST_F(AMirScreen, support_multiple_handlers)
+{
+    bool another_handler_called = false;
+
+    mir_screen->register_active_outputs_handler(this, active_outputs_handler);
+    // Use a different object as an owner for additional handler
+    mir_screen->register_active_outputs_handler(&display,
+        [&another_handler_called](usc::ActiveOutputs const&)
+            { another_handler_called = true; });
+
+    EXPECT_TRUE(another_handler_called);
+
+    another_handler_called = false;
+    mir_screen->configuration_applied(ut::fake_shared(stub_display_configuration));
+    EXPECT_TRUE(another_handler_called);
+
+    mir_screen->unregister_active_outputs_handler(&display);
 }


### PR DESCRIPTION
On some device, the touchscreen is still turned on even the screen is
off. To prevent the input from getting sent to the client, the session
switcher is modified to also listen to active outputs changes and hide
all sessions if all outputs are off.

Note that this PR changes the meaning of the "ActiveOutputs" property exposed on DBus.

This PR comes with a Jenkinsfile update.

Fixes ubports/ubuntu-touch#1087