### PR TITLE
Make the code compatible with newer Mir while still compilable on Mir 1.2

### DIFF
--- a/src/mir_screen.cpp
+++ b/src/mir_screen.cpp
@@ -18,6 +18,7 @@
 
 #include "mir_screen.h"
 
+#include <mir/version.h>
 #include <mir/compositor/compositor.h>
 #include <mir/graphics/display.h>
 #include <mir/graphics/display_configuration.h>
@@ -216,13 +217,21 @@ void usc::MirScreen::base_configuration_updated(
 }
 
 void usc::MirScreen::session_configuration_applied(
+#if MIR_SERVER_VERSION >= MIR_VERSION_NUMBER(1, 6, 0)
     std::shared_ptr<mir::scene::Session> const&,
+#else
+    std::shared_ptr<mir::frontend::Session> const&,
+#endif
     std::shared_ptr<mir::graphics::DisplayConfiguration> const&)
 {
 }
 
 void usc::MirScreen::session_configuration_removed(
+#if MIR_SERVER_VERSION >= MIR_VERSION_NUMBER(1, 6, 0)
     std::shared_ptr<mir::scene::Session> const&)
+#else
+    std::shared_ptr<mir::frontend::Session> const&)
+#endif
 {
 }
 
@@ -238,11 +247,13 @@ void usc::MirScreen::catastrophic_configuration_error(
 {
 }
 
+#if MIR_SERVER_VERSION >= MIR_VERSION_NUMBER(1, 6, 0)
 void usc::MirScreen::configuration_updated_for_session(
     std::shared_ptr<mir::scene::Session> const&,
     std::shared_ptr<mir::graphics::DisplayConfiguration const> const&)
 {
 }
+#endif
 
 void usc::MirScreen::set_power_mode(MirPowerMode mode, SetPowerModeFilter const& filter)
 try

--- a/src/mir_screen.cpp
+++ b/src/mir_screen.cpp
@@ -216,13 +216,13 @@ void usc::MirScreen::base_configuration_updated(
 }
 
 void usc::MirScreen::session_configuration_applied(
-    std::shared_ptr<mir::frontend::Session> const&,
+    std::shared_ptr<mir::scene::Session> const&,
     std::shared_ptr<mir::graphics::DisplayConfiguration> const&)
 {
 }
 
 void usc::MirScreen::session_configuration_removed(
-    std::shared_ptr<mir::frontend::Session> const&)
+    std::shared_ptr<mir::scene::Session> const&)
 {
 }
 
@@ -235,6 +235,12 @@ void usc::MirScreen::configuration_failed(
 void usc::MirScreen::catastrophic_configuration_error(
     std::shared_ptr<mir::graphics::DisplayConfiguration const> const&,
     std::exception const&)
+{
+}
+
+void usc::MirScreen::configuration_updated_for_session(
+    std::shared_ptr<mir::scene::Session> const&,
+    std::shared_ptr<mir::graphics::DisplayConfiguration const> const&)
 {
 }
 

--- a/src/mir_screen.h
+++ b/src/mir_screen.h
@@ -19,6 +19,7 @@
 #ifndef USC_MIR_SCREEN_H_
 #define USC_MIR_SCREEN_H_
 
+#include <mir/version.h>
 #include <mir/graphics/display_configuration_observer.h>
 #include "screen.h"
 
@@ -58,19 +59,30 @@ public:
     void base_configuration_updated(
         std::shared_ptr<mir::graphics::DisplayConfiguration const> const&) override;
     void session_configuration_applied(
+#if MIR_SERVER_VERSION >= MIR_VERSION_NUMBER(1, 6, 0)
         std::shared_ptr<mir::scene::Session> const&,
+#else
+        std::shared_ptr<mir::frontend::Session> const&,
+#endif
         std::shared_ptr<mir::graphics::DisplayConfiguration> const&) override;
     void session_configuration_removed(
-        std::shared_ptr<mir::scene::Session> const&) override;
+#if MIR_SERVER_VERSION >= MIR_VERSION_NUMBER(1, 6, 0)
+        std::shared_ptr<mir::scene::Session> const&
+#else
+        std::shared_ptr<mir::frontend::Session> const&
+#endif
+        ) override;
     void configuration_failed(
         std::shared_ptr<mir::graphics::DisplayConfiguration const> const&,
         std::exception const&) override;
     void catastrophic_configuration_error(
         std::shared_ptr<mir::graphics::DisplayConfiguration const> const&,
         std::exception const&) override;
+#if MIR_SERVER_VERSION >= MIR_VERSION_NUMBER(1, 6, 0)
     void configuration_updated_for_session(
         std::shared_ptr<mir::scene::Session> const&,
         std::shared_ptr<mir::graphics::DisplayConfiguration const> const&) override;
+#endif
 
 private:
     using SetPowerModeFilter = bool(*)(mir::graphics::UserDisplayConfigurationOutput const&);

--- a/src/mir_screen.h
+++ b/src/mir_screen.h
@@ -58,16 +58,19 @@ public:
     void base_configuration_updated(
         std::shared_ptr<mir::graphics::DisplayConfiguration const> const&) override;
     void session_configuration_applied(
-        std::shared_ptr<mir::frontend::Session> const&,
+        std::shared_ptr<mir::scene::Session> const&,
         std::shared_ptr<mir::graphics::DisplayConfiguration> const&) override;
     void session_configuration_removed(
-        std::shared_ptr<mir::frontend::Session> const&) override;
+        std::shared_ptr<mir::scene::Session> const&) override;
     void configuration_failed(
         std::shared_ptr<mir::graphics::DisplayConfiguration const> const&,
         std::exception const&) override;
     void catastrophic_configuration_error(
         std::shared_ptr<mir::graphics::DisplayConfiguration const> const&,
         std::exception const&) override;
+    void configuration_updated_for_session(
+        std::shared_ptr<mir::scene::Session> const&,
+        std::shared_ptr<mir::graphics::DisplayConfiguration const> const&) override;
 
 private:
     using SetPowerModeFilter = bool(*)(mir::graphics::UserDisplayConfigurationOutput const&);

--- a/src/session_monitor.h
+++ b/src/session_monitor.h
@@ -24,7 +24,7 @@
 #include <memory>
 #include <string>
 
-namespace mir { namespace frontend { class Session; }};
+namespace mir { namespace scene { class Session; }};
 
 namespace usc
 {
@@ -37,7 +37,7 @@ public:
     virtual void show() = 0;
     virtual void hide() = 0;
     virtual void raise_and_focus() = 0;
-    virtual bool corresponds_to(mir::frontend::Session const*) = 0;
+    virtual bool corresponds_to(mir::scene::Session const*) = 0;
 
 protected:
     Session() = default;
@@ -49,8 +49,8 @@ class SessionMonitor
 {
 public:
     virtual void add(std::shared_ptr<Session> const& session, pid_t pid) = 0;
-    virtual void remove(std::shared_ptr<mir::frontend::Session> const& session) = 0;
-    virtual void mark_ready(mir::frontend::Session const* session) = 0;
+    virtual void remove(std::shared_ptr<mir::scene::Session> const& session) = 0;
+    virtual void mark_ready(mir::scene::Session const* session) = 0;
 
 protected:
     SessionMonitor() = default;

--- a/src/session_switcher.cpp
+++ b/src/session_switcher.cpp
@@ -22,7 +22,7 @@
 #include "spinner.h"
 #include "screen.h"
 
-#include <mir/frontend/session.h>
+#include <mir/scene/session.h>
 
 usc::SessionSwitcher::SessionSwitcher(std::shared_ptr<Spinner> const& spinner)
     : spinner_process{spinner},
@@ -64,7 +64,7 @@ void usc::SessionSwitcher::add(std::shared_ptr<Session> const& session, pid_t pi
     update_displayed_sessions();
 }
 
-void usc::SessionSwitcher::remove(std::shared_ptr<mir::frontend::Session> const& session)
+void usc::SessionSwitcher::remove(std::shared_ptr<mir::scene::Session> const& session)
 {
     std::lock_guard<std::mutex> lock{mutex};
 
@@ -105,7 +105,7 @@ void usc::SessionSwitcher::set_next_session(std::string const& name)
     update_displayed_sessions();
 }
 
-void usc::SessionSwitcher::mark_ready(mir::frontend::Session const* session)
+void usc::SessionSwitcher::mark_ready(mir::scene::Session const* session)
 {
     std::lock_guard<std::mutex> lock{mutex};
 

--- a/src/session_switcher.h
+++ b/src/session_switcher.h
@@ -41,8 +41,8 @@ public:
 
     /* From SessionMonitor */
     void add(std::shared_ptr<Session> const& session, pid_t pid) override;
-    void remove(std::shared_ptr<mir::frontend::Session> const& session) override;
-    void mark_ready(mir::frontend::Session const* session) override;
+    void remove(std::shared_ptr<mir::scene::Session> const& session) override;
+    void mark_ready(mir::scene::Session const* session) override;
 
     /* From DMMessageHandler */
     void set_active_session(std::string const& name) override;

--- a/src/window_manager.cpp
+++ b/src/window_manager.cpp
@@ -74,7 +74,7 @@ public:
         focus_controller.set_focus_to(scene_session, surface);
     }
 
-    bool corresponds_to(mir::frontend::Session const* s) override
+    bool corresponds_to(mir::scene::Session const* s) override
     {
         return scene_session.get() == s;
     }

--- a/tests/unit-tests/test_session_switcher.cpp
+++ b/tests/unit-tests/test_session_switcher.cpp
@@ -100,11 +100,20 @@ public:
         : name_{name}
     {}
 
+#if MIR_SERVER_VERSION >= MIR_VERSION_NUMBER(1, 6, 0)
     std::shared_ptr<mir::compositor::BufferStream> create_buffer_stream(mir::graphics::BufferProperties const& /*props*/) override { return {}; }
     void destroy_buffer_stream(std::shared_ptr<mir::frontend::BufferStream> const& /*stream*/) override {}
+#else
+    mir::frontend::BufferStreamId create_buffer_stream(mir::graphics::BufferProperties const& /*props*/) override { return {}; }
+    std::shared_ptr<mir::frontend::BufferStream> get_buffer_stream(mir::frontend::BufferStreamId /*stream*/) const override { return nullptr; }
+    void destroy_buffer_stream(mir::frontend::BufferStreamId /*stream*/) override {}
+#endif
 
     void send_error(mir::ClientVisibleError const&) override {}
     std::string name() const override { return name_; }
+#if MIR_SERVER_VERSION < MIR_VERSION_NUMBER(1, 6, 0)
+    void send_display_config(mir::graphics::DisplayConfiguration const&) override {}
+#endif
     void send_input_config(MirInputConfig const&) override {}
 
     pid_t process_id() const override { return -1; };
@@ -127,12 +136,23 @@ public:
 
     void resume_prompt_session() override {};
 
+#if MIR_SERVER_VERSION >= MIR_VERSION_NUMBER(1, 6, 0)
     std::shared_ptr<mir::scene::Surface> create_surface(
         std::shared_ptr<Session> const&,
         mir::scene::SurfaceCreationParameters const&,
         std::shared_ptr<mir::scene::SurfaceObserver> const&) override { return nullptr; };
-
     void destroy_surface(std::shared_ptr<mir::scene::Surface> const&) override { };
+#else
+    mir::frontend::SurfaceId create_surface(
+        mir::scene::SurfaceCreationParameters const& params,
+        std::shared_ptr<mir::frontend::EventSink> const& sink) override { return {}; };
+    std::shared_ptr<mir::frontend::Surface> get_surface(
+        mir::frontend::SurfaceId) const override { return nullptr; };
+    std::shared_ptr<mir::scene::Surface> surface(
+        mir::frontend::SurfaceId) const override { return nullptr; };        
+    void destroy_surface(mir::frontend::SurfaceId) override { };
+    void destroy_surface(std::weak_ptr<mir::scene::Surface> const&) override { };
+#endif
 
     std::shared_ptr<mir::scene::Surface> surface_after(
         std::shared_ptr<mir::scene::Surface> const&) const override { return nullptr; };

--- a/tests/unit-tests/test_session_switcher.cpp
+++ b/tests/unit-tests/test_session_switcher.cpp
@@ -22,7 +22,7 @@
 #include "src/spinner.h"
 #include "usc/test/mock_screen.h"
 
-#include "mir/frontend/session.h"
+#include "mir/scene/session.h"
 #include <mir/version.h>
 
 #include <gtest/gtest.h>
@@ -93,47 +93,53 @@ private:
     }
 };
 
-class StubMirSession : public mir::frontend::Session
+class StubMirSession : public mir::scene::Session
 {
 public:
     StubMirSession(std::string const& name)
         : name_{name}
     {}
 
-    std::shared_ptr<mir::frontend::Surface> get_surface(mir::frontend::SurfaceId surface) const override { return nullptr; }
+    std::shared_ptr<mir::compositor::BufferStream> create_buffer_stream(mir::graphics::BufferProperties const& /*props*/) override { return {}; }
+    void destroy_buffer_stream(std::shared_ptr<mir::frontend::BufferStream> const& /*stream*/) override {}
 
-    mir::frontend::BufferStreamId create_buffer_stream(mir::graphics::BufferProperties const& /*props*/) override { return {}; }
-    std::shared_ptr<mir::frontend::BufferStream> get_buffer_stream(mir::frontend::BufferStreamId /*stream*/) const override { return nullptr; }
-    void destroy_buffer_stream(mir::frontend::BufferStreamId /*stream*/) override {}
-    #if MIR_SERVER_VERSION < MIR_VERSION_NUMBER(0, 28, 0)
-    mir::graphics::BufferID create_buffer(mir::graphics::BufferProperties const&) override
-    {
-        return {};
-    }
-#if MIR_SERVER_VERSION >= MIR_VERSION_NUMBER(0, 27, 0)
-    mir::graphics::BufferID create_buffer(mir::geometry::Size, MirPixelFormat) override
-    {
-        return {};
-    }
-    mir::graphics::BufferID create_buffer(mir::geometry::Size, uint32_t, uint32_t) override
-    {
-        return {};
-    }
-#endif
-    void destroy_buffer(mir::graphics::BufferID) override
-    {
-    }
-    std::shared_ptr<mir::graphics::Buffer> get_buffer(mir::graphics::BufferID) override
-    {
-        return nullptr;
-    }
-    #endif
-    void send_error(mir::ClientVisibleError const&) override
-    {
-    }
+    void send_error(mir::ClientVisibleError const&) override {}
     std::string name() const override { return name_; }
-    void send_display_config(mir::graphics::DisplayConfiguration const&) override {}
     void send_input_config(MirInputConfig const&) override {}
+
+    pid_t process_id() const override { return -1; };
+
+    void take_snapshot(mir::scene::SnapshotCallback const&) override {};
+
+    std::shared_ptr<mir::scene::Surface> default_surface() const override { return nullptr; };
+
+    void set_lifecycle_state(MirLifecycleState state) override {};
+
+    void hide() override {};
+
+    void show() override {};
+
+    void start_prompt_session() override {};
+
+    void stop_prompt_session() override {};
+
+    void suspend_prompt_session() override {};
+
+    void resume_prompt_session() override {};
+
+    std::shared_ptr<mir::scene::Surface> create_surface(
+        std::shared_ptr<Session> const&,
+        mir::scene::SurfaceCreationParameters const&,
+        std::shared_ptr<mir::scene::SurfaceObserver> const&) override { return nullptr; };
+
+    void destroy_surface(std::shared_ptr<mir::scene::Surface> const&) override { };
+
+    std::shared_ptr<mir::scene::Surface> surface_after(
+        std::shared_ptr<mir::scene::Surface> const&) const override { return nullptr; };
+
+    void configure_streams(
+        mir::scene::Surface& surface,
+        std::vector<mir::shell::StreamSpecification> const& config) override { };
 
 private:
     std::string const name_;
@@ -174,12 +180,12 @@ public:
         fake_scene.raise(this);
     }
 
-    bool corresponds_to(mir::frontend::Session const* s) override
+    bool corresponds_to(mir::scene::Session const* s) override
     {
         return s == mir_stub_session.get();
     }
 
-    std::shared_ptr<mir::frontend::Session> corresponding_session()
+    std::shared_ptr<mir::scene::Session> corresponding_session()
     {
         return mir_stub_session;
     }


### PR DESCRIPTION
This is primarily @mariogrip's work. I added `#ifdef` to make the code works on older Mir too. This reduces the divergence for edge (when someone rebases edge after this).