### PR TITLE
[session_switcher] Add wayland workaround

### DIFF
--- a/src/session_switcher.cpp
+++ b/src/session_switcher.cpp
@@ -27,8 +27,10 @@
 usc::SessionSwitcher::SessionSwitcher(std::shared_ptr<Spinner> const& spinner)
     : spinner_process{spinner},
       booting{true},
-      has_active_outputs{true}
+      has_active_outputs{true},
+      wayland{!!getenv("WAYLAND_DISPLAY")}
 {
+    if (wayland) printf("Using wayland workaround!\n");
 }
 
 usc::SessionSwitcher::~SessionSwitcher()
@@ -57,11 +59,12 @@ void usc::SessionSwitcher::add(std::shared_ptr<Session> const& session, pid_t pi
 {
     std::lock_guard<std::mutex> lock{mutex};
 
-
+    // WAYLAND HACK
+    // Wayland currently does not give us any session name
     if (pid == spinner_process->pid()) {
-        sessions[session->name()] = SessionInfo(session, true);
+        sessions[wayland ? "spinner" : session->name()] = SessionInfo(session, true);
     } else {
-        sessions[session->name()] = SessionInfo(session);
+        sessions[wayland ? "session-0" : session->name()] = SessionInfo(session);
     }
 
     update_displayed_sessions();

--- a/src/session_switcher.h
+++ b/src/session_switcher.h
@@ -84,6 +84,7 @@ private:
     bool booting;
     std::weak_ptr<Screen> screen_weak;
     bool has_active_outputs;
+    const bool wayland;
 };
 
 }

--- a/src/session_switcher.h
+++ b/src/session_switcher.h
@@ -66,12 +66,14 @@ private:
     struct SessionInfo
     {
         SessionInfo() = default;
-        explicit SessionInfo(std::shared_ptr<Session> session)
-            : session{session}
+        explicit SessionInfo(std::shared_ptr<Session> session, bool spinner = false)
+            : session{session},
+              is_spinner{spinner}
         {
         }
         std::shared_ptr<Session> session;
         bool ready = false;
+        bool is_spinner = false;
     };
 
     std::mutex mutex;
@@ -79,7 +81,6 @@ private:
     std::map<std::string, SessionInfo> sessions;
     std::string active_name;
     std::string next_name;
-    std::string spinner_name;
     bool booting;
     std::weak_ptr<Screen> screen_weak;
     bool has_active_outputs;
@@ -88,4 +89,3 @@ private:
 }
 
 #endif
-


### PR DESCRIPTION
This adds a wayland workaround by hardcoding the session names as
wayland does not gives us any session names yet.

This should be removed once the issue has been fixed.

Merge https://github.com/ubports/unity-system-compositor/pull/21 first 